### PR TITLE
Fix: Prevent cookie creation on data-cookie-enabled="false"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ var tracker = function (w) {
     (getParameterByName('api') || 'https://api.tinybird.co') + '/v0/events'
   var dataSource = getParameterByName('source')
   var token = getParameterByName('token')
-  var cookieEnabled = getParameterByName('cookie-enabled') != null ? getParameterByName('cookie-enabled') : true
+  var cookieEnabled = getParameterByName('cookie-enabled') === 'false' ? false : true
   var cookieDomain = getParameterByName('cookie-domain') || w.location.hostname
   var functionName = getParameterByName('function') || 'tinybird'
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -409,7 +409,7 @@ describe('Tracker', () => {
           {
             'data-source': 'hey',
             'data-token': 'token',
-            'data-cookie-enabled': false
+            'data-cookie-enabled': 'false'
           }
         ),
         addEventListener: jest.fn()
@@ -480,7 +480,7 @@ describe('Tracker', () => {
             {
               'data-source': 'hey',
               'data-token': 'token',
-              'data-cookie-enabled': false
+              'data-cookie-enabled': 'false'
             }
           ),
           addEventListener: jest.fn()
@@ -548,7 +548,7 @@ describe('Tracker', () => {
             {
               'data-source': 'hey',
               'data-token': 'token',
-              'data-cookie-enabled': false
+              'data-cookie-enabled': 'false'
             }
           ),
           addEventListener: jest.fn(),


### PR DESCRIPTION
Today I've discovered that there's no way to prevent the library to create a new cookie even if I add the attribute `data-cookie-enabled="false"`.

I've been reading the code and I've discovered that we're managing the value of the `data-cookie-enabled` as a boolean but, instead, it's passed as a string and when we test if it's equal to `null` it's treated as a truthy value causing the unexpected behaviour.

```js
// data-cookie-enabled="false"
getParameterByName('cookie-enabled') // returns 'false' as string (truthy value)

// data-cookie-enabled="true"
getParameterByName('cookie-enabled') // returns 'true' as string (a truthy value too)
```

And, therefore, the following statement always returns a truthy value (string or `true`):
```js
var cookieEnabled = getParameterByName('cookie-enabled') != null ? getParameterByName('cookie-enabled') : true
```

The tests hasn't prevented these errors because we are passing the value as boolean. I've changed it to 'false' and three tests have failed so I've modified the code after that and now everything should work as expected.